### PR TITLE
Filtrado por estado de un pedido

### DIFF
--- a/OrderNow-Dashboard/src/components/Button/Button.jsx
+++ b/OrderNow-Dashboard/src/components/Button/Button.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Button = ({ children, className, text, onClick, disabled = false}) => {
+const Button = ({ children, className, text, onClick, id, disabled = false}) => {
   const colorVariants = {
     red:'bg-red-500 hover:bg-red-700',
     green: 'bg-green-500 hover:bg-green-700',
@@ -27,6 +27,7 @@ const Button = ({ children, className, text, onClick, disabled = false}) => {
       onClick={onClick}
       className={`${className}`}
       disabled={disabled}
+      id={id}
     >
       {text}
       {children}

--- a/OrderNow-Dashboard/src/components/filter/CheckboxFilter.jsx
+++ b/OrderNow-Dashboard/src/components/filter/CheckboxFilter.jsx
@@ -6,27 +6,18 @@ function CheckboxFilter({ title, items, resetName, onChange}) {
   const [selectedItems, setSelectedItems] = useState([])
 
   const handleChange = (event) => {
-    const checked = event.target.checked;
-    const targetKey = event.target.id;
-    let newSelectedItems;
-    if (checked) {
-        setCounterSelected(counterSelected + 1);
-        newSelectedItems = [...selectedItems, targetKey];
-        setSelectedItems(newSelectedItems);
-    } 
+    
+    let newSelectedItems = [];
+
+    if(event.target.id !== "reset") {
+      setCounterSelected((prevCounterSelected) => (event.target.checked ? (prevCounterSelected + 1) : (prevCounterSelected - 1)));
+      newSelectedItems = (event.target.checked ? ([...selectedItems, event.target.id]) : (selectedItems.filter(id => id !== event.target.id)));
+    }
     else {
-        newSelectedItems = selectedItems.filter(id => id !== targetKey);
-        setSelectedItems(newSelectedItems);
-        setCounterSelected(counterSelected - 1);
+      setCounterSelected(0);
     }
 
-    onChange(newSelectedItems);
-  };
-
-  const handleChangeReset = () => {
-    const newSelectedItems = [];
-    setCounterSelected(0);
-    setSelectedItems(newSelectedItems);
+    setSelectedItems(newSelectedItems)
     onChange(newSelectedItems);
   }
   
@@ -64,7 +55,8 @@ function CheckboxFilter({ title, items, resetName, onChange}) {
               <Button
                 type="button"
                 className="text-sm text-gray-700 underline transition-colors hover:text-gray-900"
-                onClick={handleChangeReset}
+                onClick={handleChange}
+                id="reset"
               >
                 {resetName}
               </Button>
@@ -83,7 +75,7 @@ function CheckboxFilter({ title, items, resetName, onChange}) {
                     type="checkbox"
                     className="size-5 rounded border-gray-300 shadow-sm"
                     id={key}
-                    onChange={(event) => handleChange(event)}
+                    onChange={handleChange}
                     checked={selectedItems.includes(key)}
                   />
 

--- a/OrderNow-Dashboard/src/components/filter/CheckboxFilter.jsx
+++ b/OrderNow-Dashboard/src/components/filter/CheckboxFilter.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import Button from "../Button/Button";
+
+function CheckboxFilter({ title, items, resetName, onChange}) {
+  const [counterSelected, setCounterSelected] = useState(0);
+  const [selectedItems, setSelectedItems] = useState([])
+
+  const handleChange = (event) => {
+    const checked = event.target.checked;
+    const targetKey = event.target.id;
+    let newSelectedItems;
+    if (checked) {
+        setCounterSelected(counterSelected + 1);
+        newSelectedItems = [...selectedItems, targetKey];
+        setSelectedItems(newSelectedItems);
+    } 
+    else {
+        newSelectedItems = selectedItems.filter(id => id !== targetKey);
+        setSelectedItems(newSelectedItems);
+        setCounterSelected(counterSelected - 1);
+    }
+
+    onChange(newSelectedItems);
+  };
+
+  const handleChangeReset = () => {
+    const newSelectedItems = [];
+    setCounterSelected(0);
+    setSelectedItems(newSelectedItems);
+    onChange(newSelectedItems);
+  }
+  
+  return (
+    <div className="space-y-4 inline-block relative">
+      <details className="group overflow-visible rounded border border-gray-300 shadow-sm">
+        <summary className="flex items-center justify-between gap-2 p-3 text-gray-700 transition-colors hover:text-gray-900 [&::-webkit-details-marker]:hidden">
+          <span className="text-sm font-medium"> {title} </span>
+
+          <span className="transition-transform group-open:-rotate-180">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              className="size-4"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+              />
+            </svg>
+          </span>
+        </summary>
+
+        <div className="absolute left-0 mt-1 divide-y divide-gray-300 bg-gray-200 rounded-lg border-red-900">
+          <div className="flex items-center justify-between px-3 py-2 gap-10">
+            <span className="text-sm text-gray-700">
+              {counterSelected} {counterSelected === 1 ? "Seleccionado" : "Seleccionados"}
+            </span>
+
+            <div className="flex flex-row gap-5">
+              <Button
+                type="button"
+                className="text-sm text-gray-700 underline transition-colors hover:text-gray-900"
+                onClick={handleChangeReset}
+              >
+                {resetName}
+              </Button>
+            </div>
+          </div>
+
+          <fieldset className="p-3">
+            <div className="flex flex-col items-start gap-3">
+              {Object.entries(items).map(([key, value]) => (
+                <label
+                  key={key}
+                  htmlFor={key}
+                  className="inline-flex items-center gap-3"
+                >
+                  <input
+                    type="checkbox"
+                    className="size-5 rounded border-gray-300 shadow-sm"
+                    id={key}
+                    onChange={(event) => handleChange(event)}
+                    checked={selectedItems.includes(key)}
+                  />
+
+                  <span className="text-sm font-medium text-gray-700">
+                    {value}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+export default CheckboxFilter;

--- a/OrderNow-Dashboard/src/components/layout/Navbar.jsx
+++ b/OrderNow-Dashboard/src/components/layout/Navbar.jsx
@@ -18,7 +18,7 @@ const NavBar = () => {
   ];
 
   return (
-    <nav className="bg-white border-gray-200 dark:bg-gray-900 fixed top-0 left-0 w-full">
+    <nav className="bg-white border-gray-200 dark:bg-gray-900 fixed top-0 left-0 w-full z-10">
       <div className="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
         <a href="/" className="flex items-center">
           <img src="https://flowbite.com/docs/images/logo.svg" className="h-8 mr-3" alt="Flowbite Logo" />

--- a/OrderNow-Dashboard/src/config/order-status.js
+++ b/OrderNow-Dashboard/src/config/order-status.js
@@ -6,3 +6,12 @@ export const ORDER_STATUS = {
     PREPARING: 5,
     ACCEPTED: 6
 };
+
+export const ORDER_STATUS_NAMES = {
+    [ORDER_STATUS.PENDING]: "Pendiente",
+    [ORDER_STATUS.ON_THE_WAY]: "En Camino",
+    [ORDER_STATUS.DELIVERED]: "Entregado",
+    [ORDER_STATUS.CANCELED]: "Cancelado",
+    [ORDER_STATUS.ACCEPTED]: "Aceptado",
+    [ORDER_STATUS.PREPARING]: "Preparando" 
+}

--- a/OrderNow-Dashboard/src/pages/OrderDashboard.jsx
+++ b/OrderNow-Dashboard/src/pages/OrderDashboard.jsx
@@ -3,12 +3,16 @@ import { formatDate } from "../utils/formatDate";
 import OrderDetail from "../components/order-detail/OrderDetail";
 import getSupaBaseClient from "../supabase/supabase-client";
 import { ORDER_STATUS } from "../config/order-status";
+import { ORDER_STATUS_NAMES } from "../config/order-status";
 import ConfirmationModal from "../components/confirmation-modal/ConfirmationModal";
 import Button from "../components/Button/Button";
-import { Link } from 'react-router-dom';
 import TotalOrdersCard from "../components/TotalOrderCard/TotalOrderCard";
+import CheckboxFilter from "../components/filter/CheckboxFilter";
+import FilterService from "../services/FilterService";
+
 
 const supaBase = getSupaBaseClient();
+const filterService = new FilterService();
 
 const OrdersDashboard = () => {
   const [orders, setOrders] = useState([]);
@@ -20,7 +24,9 @@ const OrdersDashboard = () => {
   const [confirmAction, setConfirmAction] = useState(null);
   const [titleConfirmationModal, setTitleConfirmationModal] = useState("");
   const [bodyConfirmationModal, setBodyConfirmationModal] = useState("");
+  const [seletedStatusFilters, setSeletedStatusFilters] = useState([]);
   const isUpdating = useRef(false);
+  const ordersRef = useRef([]);
 
   const closeDetailModal = () => setDetailModalOpen(false);
   const closeConfirmationModal = () => setConfirmationModalOpen(false);
@@ -116,7 +122,8 @@ const OrdersDashboard = () => {
       };
     });
 
-    setOrders(enrichedOrders);
+    ordersRef.current = enrichedOrders;
+    setOrders(filterService.filterByStatus(ordersRef.current, seletedStatusFilters));
     setLoading(false);
   };
 
@@ -135,7 +142,7 @@ const OrdersDashboard = () => {
               Pedidos del Restaurante
             </h1>
 
-
+           
 
             {loading ? (
               <p className="text-center text-gray-500">Cargando pedidos...</p>
@@ -144,6 +151,10 @@ const OrdersDashboard = () => {
                 <div className="p-6">
                   <TotalOrdersCard totalOrders={orders.length} />
                 </div>
+                <CheckboxFilter title="Estado" items={ORDER_STATUS_NAMES} resetName="Reiniciar" onChange={(items) => {
+                 setSeletedStatusFilters(items);
+                 setOrders(filterService.filterByStatus(ordersRef.current, items));
+                }}/>
                 <div className="hidden md:grid grid-cols-10 bg-gray-100 text-gray-600 font-semibold px-8 py-3 shadow-sm text-sm">
                   <span className="w-12">ID</span>
                   <span className="w-28">Fecha</span>

--- a/OrderNow-Dashboard/src/services/FilterService.js
+++ b/OrderNow-Dashboard/src/services/FilterService.js
@@ -1,0 +1,20 @@
+export default class FilterService {
+    filterByStatus(orders, selectedStatusId) {
+
+        if(selectedStatusId.length === 0)
+            return orders;
+
+        try {
+
+            selectedStatusId = selectedStatusId.map(id => parseInt(id));
+            orders = orders.filter((order) => selectedStatusId.includes(order.state_type_id));
+            
+            return orders;
+        }
+        catch(err)
+        {
+            console.error("Ha ocurrido un error inesperado", err);
+        }
+
+    }
+}


### PR DESCRIPTION
Como restaurante\
Quiero filtrar mis pedidos por su estado\
Para poder organizarme de una mejor manera\
\
**<u>Criterios de aceptación</u>**\
**Escenario: Sin filtro seleccionado**\
Dado que el restaurante esté en la sección de pedidos\
Cuando no seleccione ninguna opción del filtrado por estado\
Entonces el sistemá mostrará los pedidos de una manera arbitraria\
\
**Escenario: Filtro seleccionado**\
Dado que el restaurante esté en la sección de pedidos\
Cuando seleccione un filtro\
Entonces el sistemá mostrará solamente los pedidos con este estado\
\
**Escenario: Filtro seleccionado (Cancelado)**\
Dado que el restaurante esté en la sección de pedidos\
Cuando seleccione el filtro para pedidos cancelados\
Entonces el sistema mostrará solamente los pedidos cancelados\
Y no podrá alterar su estado.

[Link HU Plane](http://159.69.123.44/isw/browse/TALLE-339/)

# Prueba
![image](https://github.com/user-attachments/assets/29bcd2b4-6c1c-450d-b9c0-54569f2265fb)
![image](https://github.com/user-attachments/assets/43056ab7-47c6-4821-9fc4-9df8053fb9c1)
![image](https://github.com/user-attachments/assets/cc0cf885-01c9-4f1f-91a3-43219777a17b)
