### PR TITLE
Mapa como modal

### DIFF
--- a/OrderNow-React/package.json
+++ b/OrderNow-React/package.json
@@ -16,9 +16,11 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
     "@tailwindcss/vite": "^4.1.4",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.487.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.5.1",
     "supertokens-web-js": "^0.15.0",
     "tailwindcss": "^4.1.4"

--- a/OrderNow-React/src/components/MapModal.jsx
+++ b/OrderNow-React/src/components/MapModal.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl,
+  iconUrl,
+  shadowUrl
+});
+
+const SANTA_CRUZ_CENTER = [-17.7833, -63.1833];
+
+const MapModal = ({ isOpen, onClose, origin, destination }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative bg-white rounded-lg w-full max-w-4xl mx-4 z-10">
+        <button
+          onClick={onClose}
+          className="absolute right-2 top-2 z-10 p-2 text-gray-500 hover:text-gray-700"
+        >
+          ✕
+        </button>
+        <div className="h-[600px] w-full rounded-lg overflow-hidden">
+          <MapContainer
+            center={SANTA_CRUZ_CENTER}
+            zoom={13}
+            style={{ height: '100%', width: '100%' }}
+          >
+            <TileLayer
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            />
+            {origin && <Marker position={[origin.lat, origin.lng]} />}
+            {destination && <Marker position={[destination.lat, destination.lng]} />}
+          </MapContainer>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MapModal;

--- a/OrderNow-React/src/pages/Layout.jsx
+++ b/OrderNow-React/src/pages/Layout.jsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../components/layout/NavBar';
 import Footer from '../components/layout/Footer';
+import Button from '../components/atoms/Button';
+import MapModal from '../components/MapModal';
 
 const Layout = ({ children }) => {
+  const [isMapOpen, setIsMapOpen] = useState(false);
+
   return (
     <div className="flex flex-col min-h-screen">
       <NavBar />
@@ -10,6 +14,19 @@ const Layout = ({ children }) => {
       <main className="flex-grow">
         {children}
       </main>
+      <div className="fixed bottom-4 right-4">
+        <Button
+          label="Ver Mapa"
+          onClick={() => setIsMapOpen(true)}
+          className="shadow-lg"
+        />
+      </div>
+      <MapModal
+        isOpen={isMapOpen}
+        onClose={() => setIsMapOpen(false)}
+        origin={{ lat: -17.7833, lng: -63.1833 }}
+        destination={{ lat: -17.7933, lng: -63.1933 }}
+      />
       <Footer />
     </div>
   );


### PR DESCRIPTION
**Descripción:**\
Como cliente, quiero ver el mapa como un modal que se puede cerrar fácilmente para no interrumpir mi navegación principal.

**Criterios de aceptación:**

- Dado que estoy usando la aplicación,
 Cuando abro el mapa desde una orden reciente,
 Entonces se muestra en un modal con botón de cierre claro ("X") en la esquina superior derecha.

- Dado que estoy dentro del modal del mapa, Cuando toco fuera del mapa o pulso el botón de cerrar,\ Entonces el modal se cierra y regreso a la pantalla anterior sin perder datos.

http://159.69.123.44/isw/browse/TALLE-356/