### PR TITLE
Acceder al mapa desde "Órdenes recientes"

### DIFF
--- a/OrderNow-React/package.json
+++ b/OrderNow-React/package.json
@@ -16,9 +16,11 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
     "@tailwindcss/vite": "^4.1.4",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.487.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.5.1",
     "supertokens-web-js": "^0.15.0",
     "tailwindcss": "^4.1.4"

--- a/OrderNow-React/src/components/MapModal.jsx
+++ b/OrderNow-React/src/components/MapModal.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl,
+  iconUrl,
+  shadowUrl
+});
+
+const SANTA_CRUZ_CENTER = [-17.7833, -63.1833];
+
+const MapModal = ({ isOpen, onClose, origin, destination }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative bg-white rounded-lg w-full max-w-4xl mx-4 z-10">
+        <button
+          onClick={onClose}
+          className="absolute right-2 top-2 z-10 p-2 text-gray-500 hover:text-gray-700"
+        >
+          ✕
+        </button>
+        <div className="h-[600px] w-full rounded-lg overflow-hidden">
+          <MapContainer
+            center={SANTA_CRUZ_CENTER}
+            zoom={13}
+            style={{ height: '100%', width: '100%' }}
+          >
+            <TileLayer
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            />
+            {origin && <Marker position={[origin.lat, origin.lng]} />}
+            {destination && <Marker position={[destination.lat, destination.lng]} />}
+          </MapContainer>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MapModal;

--- a/OrderNow-React/src/pages/Home.jsx
+++ b/OrderNow-React/src/pages/Home.jsx
@@ -2,9 +2,12 @@ import React, { useEffect, useState } from 'react';
 import BusinessTypeCard from '../components/BusinessTypeCard';
 import CardSlider from '../components/CardSlider';
 import getSupaBaseClient from '../supabase-client';
+import MapModal from '../components/MapModal';
 
 const Home = () => {
   const [orders, setOrders] = useState([]);
+  const [isMapOpen, setIsMapOpen] = useState(false);
+  const [selectedOrder, setSelectedOrder] = useState(null);
 
   useEffect(() => {
     const fetchOrders = async () => {
@@ -13,16 +16,20 @@ const Home = () => {
         .from('orders')
         .select('date, total_price, business_id, state_type_id, state_types(name), businesses(name)')
         .neq('state_type_id', 4)
-        .order('date', { ascending: false })
+        .order('date', { ascending: false });
 
       if (!error) setOrders(data || []);
     };
     fetchOrders();
   }, []);
 
+  const handleOrderClick = (order) => {
+    setSelectedOrder(order);
+    setIsMapOpen(true);
+  };
+
   return (
     <>
-
       <div className="w-full max-w-3xl mx-auto mt-6">
         <h3 className="text-lg font-semibold mb-2">Tus órdenes recientes</h3>
         <ul className="divide-y divide-gray-200 bg-white rounded shadow text-sm">
@@ -30,7 +37,11 @@ const Home = () => {
             <li className="p-3 text-gray-500">No tienes órdenes recientes.</li>
           )}
           {orders.map(order => (
-            <li key={order.business_id} className="flex justify-between items-center p-3">
+            <li
+              key={order.business_id}
+              className="flex justify-between items-center p-3 cursor-pointer hover:bg-gray-50"
+              onClick={() => handleOrderClick(order)}
+            >
               <div>
                 <span className="font-medium">{order.businesses?.name}</span>
                 <span className="ml-2 text-gray-400">{new Date(order.date).toLocaleDateString()}</span>
@@ -57,6 +68,13 @@ const Home = () => {
         <BusinessTypeCard />
         <BusinessTypeCard />
       </CardSlider>
+
+      <MapModal
+        isOpen={isMapOpen}
+        onClose={() => setIsMapOpen(false)}
+        origin={{ lat: -17.7833, lng: -63.1833 }}
+        destination={{ lat: -17.7840, lng: -63.1800 }}
+      />
     </>
   );
 };

--- a/OrderNow-React/src/pages/Layout.jsx
+++ b/OrderNow-React/src/pages/Layout.jsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../components/layout/NavBar';
 import Footer from '../components/layout/Footer';
+import Button from '../components/atoms/Button';
+import MapModal from '../components/MapModal';
 
 const Layout = ({ children }) => {
+  const [isMapOpen, setIsMapOpen] = useState(false);
+
   return (
     <div className="flex flex-col min-h-screen">
       <NavBar />
@@ -10,6 +14,19 @@ const Layout = ({ children }) => {
       <main className="flex-grow">
         {children}
       </main>
+      <div className="fixed bottom-4 right-4">
+        <Button
+          label="Ver Mapa"
+          onClick={() => setIsMapOpen(true)}
+          className="shadow-lg"
+        />
+      </div>
+      <MapModal
+        isOpen={isMapOpen}
+        onClose={() => setIsMapOpen(false)}
+        origin={{ lat: -17.7833, lng: -63.1833 }}
+        destination={{ lat: -17.7933, lng: -63.1933 }}
+      />
       <Footer />
     </div>
   );


### PR DESCRIPTION
**Descripción:**\
Como cliente, quiero acceder al mapa desde el menú de "Tus órdenes recientes" para ver la ubicación del restaurante y mi ubicación actual.

**Criterios de aceptación:**

- Dado que estoy en la sección de "Tus órdenes recientes",\
  Cuando selecciono una orden y pulso "Ver en mapa",\
  Entonces se abre un modal con un mapa que muestra dos marcadores: uno del restaurante y otro de mi ubicación actual.

(No definido)
- Dado que no tengo permiso de geolocalización activado,\
  Cuando intento abrir el mapa,\
  Entonces se me pide habilitar la geolocalización o ingresar manualmente mi ubicación.